### PR TITLE
fixed pillow and numpy version

### DIFF
--- a/qt_wsi_reg/registration_tree.py
+++ b/qt_wsi_reg/registration_tree.py
@@ -1181,7 +1181,7 @@ class RegistrationQuadTree:
 
         thumb = Image.new('RGB', tile.size, '#ffffff')
         thumb.paste(tile, None, tile)
-        thumb.thumbnail(size, Image.ANTIALIAS)
+        thumb.thumbnail(size, Image.LANCZOS)
         scale.append(np.array([w, h]) / thumb.size)
 
         slide.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy>=1.19.5
+numpy<2
 opencv-python>=4.5.1.48
 openslide-python>=1.1.2
 matplotlib>=3.3.4
 scikit-learn>=0.24.1
 probreg==0.3.5
-pillow>=8.1.0
+pillow>=10.0.0
 scipy>=1.5.4

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="qt-wsi-registration", 
-    version="0.0.12",
+    version="0.0.13",
     author="Christian Marzahl",
     author_email="christian.marzahl@gamil.com",
     description="Robust quad-tree based registration on whole slide images",
@@ -14,13 +14,13 @@ setuptools.setup(
     url="https://github.com/ChristianMarzahl/WsiRegistration",
     packages=setuptools.find_packages(),
     install_requires=[
-        'numpy', #>=1.19.5
+        'numpy<2', #<2
         'opencv-python', # >=4.5.1.48
         'openslide-python', #>=1.1.2
         'matplotlib', #>=3.3.4
         'scikit-learn', #>=0.24.1
         'probreg==0.3.5', #>=0.3.1
-        'pillow', # >=8.1.0
+        'pillow>10', # >10
         'scipy'
     ],
     classifiers=[


### PR DESCRIPTION
Fixed deprecated PIL.Image.ANTIALIAS method. Also set numpy<2 as there is not a numpy 2 compatible build for opencv at the moment. See https://github.com/opencv/opencv-python/issues/943.